### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.writing.txt
+++ b/LICENSE.writing.txt
@@ -1,1 +1,1 @@
-Except where otherwise noted, this work is licensed under http://creativecommons.org/licenses/by-nd/3.0/
+Except where otherwise noted, this work is licensed under https://creativecommons.org/licenses/by-nd/3.0/

--- a/README.adoc
+++ b/README.adoc
@@ -3,9 +3,9 @@ tags: [sts, spring tool suite]
 projects: []
 ---
 :spring_version: current
-:jdk: http://www.oracle.com/technetwork/java/javase/downloads/index.html
+:jdk: https://www.oracle.com/technetwork/java/javase/downloads/index.html
 :spring_boot_version: 1.5.3.RELEASE
-:pws: http://try.run.pivotal.io/sts-guide
+:pws: https://try.run.pivotal.io/sts-guide
 
 :toc:
 :icons: font
@@ -17,7 +17,7 @@ This guide walks you through the process of deploying a "hello world" Spring app
 
 You'll deploy a Spring Boot application to Cloud Foundry that will accept HTTP GET requests at:
 
-    http://gs-sts-cloud-foundry-deployment-myname.cfapps.io/greeting
+    https://gs-sts-cloud-foundry-deployment-myname.cfapps.io/greeting
   
 The application URL will vary depending on the host portion that you have to change later on in this guide.
 
@@ -27,7 +27,7 @@ The application will then respond with a web page displaying a greeting:
 
 You can customize the greeting with an optional `name` parameter in the query string:
 
-    http://gs-sts-cloud-foundry-deployment-myname.cfapps.io/greeting?name=User
+    https://gs-sts-cloud-foundry-deployment-myname.cfapps.io/greeting?name=User
 
 The `name` parameter value overrides the default value of "World" and is reflected in the response:
 
@@ -36,16 +36,16 @@ The `name` parameter value overrides the default value of "World" and is reflect
 IMPORTANT: The `myname` portion of the URL is what you will change when you deploy your application to Cloud Foundry through STS, to avoid host-taken errors during deployment.
     
 This application is based on a Spring service that serves web content. Further information on how to create the service from scratch can be found at
-http://spring.io/guides/gs/serving-web-content/[Serving Web Content with Spring MVC], or it can be imported into STS through the http://spring.io/guides/gs/sts/[Import Spring Getting Started Content wizard].
+https://spring.io/guides/gs/serving-web-content/[Serving Web Content with Spring MVC], or it can be imported into STS through the https://spring.io/guides/gs/sts/[Import Spring Getting Started Content wizard].
 
 
 == What You'll Need
 
  - About 15 minutes
- - http://spring.io/tools/sts/all[Spring Tool Suite (STS)]
+ - https://spring.io/tools/sts/all[Spring Tool Suite (STS)]
  - {jdk}[JDK 8] or later
  - {pws}[Pivotal Web Services (PWS) account]
- - http://docs.spring.io/sts/nan/v373/NewAndNoteworthy.html#bootdash[Spring Boot Dashboard]
+ - https://docs.spring.io/sts/nan/v373/NewAndNoteworthy.html#bootdash[Spring Boot Dashboard]
 
 
 == Installing STS

--- a/sample/src/main/resources/templates/greeting.html
+++ b/sample/src/main/resources/templates/greeting.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="https://www.thymeleaf.org">
 <head> 
     <title>Getting Started: Serving Web Content</title> 
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://gs-sts-cloud-foundry-deployment-myname.cfapps.io/greeting (404) with 1 occurrences migrated to:  
  https://gs-sts-cloud-foundry-deployment-myname.cfapps.io/greeting ([https](https://gs-sts-cloud-foundry-deployment-myname.cfapps.io/greeting) result 404).
* [ ] http://gs-sts-cloud-foundry-deployment-myname.cfapps.io/greeting?name=User (404) with 1 occurrences migrated to:  
  https://gs-sts-cloud-foundry-deployment-myname.cfapps.io/greeting?name=User ([https](https://gs-sts-cloud-foundry-deployment-myname.cfapps.io/greeting?name=User) result 404).
* [ ] http://try.run.pivotal.io/sts-guide (404) with 1 occurrences migrated to:  
  https://try.run.pivotal.io/sts-guide ([https](https://try.run.pivotal.io/sts-guide) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://creativecommons.org/licenses/by-nd/3.0/ with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/by-nd/3.0/ ([https](https://creativecommons.org/licenses/by-nd/3.0/) result 200).
* [ ] http://spring.io/guides/gs/serving-web-content/ with 1 occurrences migrated to:  
  https://spring.io/guides/gs/serving-web-content/ ([https](https://spring.io/guides/gs/serving-web-content/) result 200).
* [ ] http://spring.io/guides/gs/sts/ with 1 occurrences migrated to:  
  https://spring.io/guides/gs/sts/ ([https](https://spring.io/guides/gs/sts/) result 200).
* [ ] http://spring.io/tools/sts/all with 1 occurrences migrated to:  
  https://spring.io/tools/sts/all ([https](https://spring.io/tools/sts/all) result 200).
* [ ] http://www.oracle.com/technetwork/java/javase/downloads/index.html with 1 occurrences migrated to:  
  https://www.oracle.com/technetwork/java/javase/downloads/index.html ([https](https://www.oracle.com/technetwork/java/javase/downloads/index.html) result 200).
* [ ] http://www.thymeleaf.org with 1 occurrences migrated to:  
  https://www.thymeleaf.org ([https](https://www.thymeleaf.org) result 200).
* [ ] http://docs.spring.io/sts/nan/v373/NewAndNoteworthy.html with 1 occurrences migrated to:  
  https://docs.spring.io/sts/nan/v373/NewAndNoteworthy.html ([https](https://docs.spring.io/sts/nan/v373/NewAndNoteworthy.html) result 301).